### PR TITLE
Set FlowDirection on TextBox for Team2Name to LeftToRight

### DIFF
--- a/StreamOverlay/OverlayWindow.xaml
+++ b/StreamOverlay/OverlayWindow.xaml
@@ -810,7 +810,7 @@
                                              VerticalAlignment="Center"
                                              
                                              Text="{Binding Path=Team2Name, UpdateSourceTrigger=PropertyChanged}"
-                                             FlowDirection="RightToLeft"
+                                             FlowDirection="LeftToRight"
                                              Margin="0,10,60,0"
                                              Background="Transparent"
                                              BorderBrush="{x:Null}"


### PR DESCRIPTION
this fixes a bug where for a name like '[FOO] Bar', 'FOO] Bar[' is displayed instead. Checked for regressions, looks fine